### PR TITLE
Add signup custom action to events

### DIFF
--- a/models/event.py
+++ b/models/event.py
@@ -9,3 +9,11 @@ class Event(models.Model):
     location = models.CharField(max_length=75)
     game = models.ForeignKey("Game", on_delete=models.CASCADE)
     description = models.CharField(max_length=100)
+
+    @property
+    def joined(self):
+        return self.__joined
+
+    @joined.setter
+    def joined(self, value):
+        self.__joined = value

--- a/views/event.py
+++ b/views/event.py
@@ -7,7 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
-from levelupapi.models import Game, Event, Gamer
+from levelupapi.models import Game, Event, Gamer, EventGamer
 
 
 
@@ -106,6 +106,68 @@ class Events(ViewSet):
             events, many=True, context={'request': request})
         return Response(serializer.data)
 
+    @action(methods=['get', 'post', 'delete'], detail=True)
+    def signup(self, request, pk=None):
+        """Managing gamers signing up for events"""
+
+        # A gamer wants to sign up for an event
+        if request.method == "POST":
+            # The pk would be `2` if the URL above was requested
+            event = Event.objects.get(pk=pk)
+
+            # Django uses the `Authorization` header to determine
+            # which user is making the request to sign up
+            gamer = Gamer.objects.get(user=request.auth.user)
+
+            try:
+                # Determine if the user is already signed up
+                registration = EventGamer.objects.get(
+                    event=event, gamer=gamer)
+                return Response(
+                    {'message': 'Gamer already signed up this event.'},
+                    status=status.HTTP_422_UNPROCESSABLE_ENTITY
+                )
+            except EventGamer.DoesNotExist:
+                # The user is not signed up.
+                registration = EventGamer()
+                registration.event = event
+                registration.gamer = gamer
+                registration.save()
+
+                return Response({}, status=status.HTTP_201_CREATED)
+
+        # User wants to leave a previously joined event
+        elif request.method == "DELETE":
+            # Handle the case if the client specifies a game
+            # that doesn't exist
+            try:
+                event = Event.objects.get(pk=pk)
+            except Event.DoesNotExist:
+                return Response(
+                    {'message': 'Event does not exist.'},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+
+            # Get the authenticated user
+            gamer = Gamer.objects.get(user=request.auth.user)
+
+            try:
+                # Try to delete the signup
+                registration = EventGamer.objects.get(
+                    event=event, gamer=gamer)
+                registration.delete()
+                return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+            except EventGamer.DoesNotExist:
+                return Response(
+                    {'message': 'Not currently registered for event.'},
+                    status=status.HTTP_404_NOT_FOUND
+                )
+
+        # If the client performs a request with a method of
+        # anything other than POST or DELETE, tell client that
+        # the method is not supported
+        return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
 class EventUserSerializer(serializers.ModelSerializer):
     """JSON serializer for event organizer's related Django user"""
@@ -141,3 +203,5 @@ class EventSerializer(serializers.HyperlinkedModelSerializer):
         )
         fields = ('id', 'url', 'game', 'gamer',
                   'description', 'day', 'time')
+
+                  

--- a/views/event.py
+++ b/views/event.py
@@ -95,12 +95,24 @@ class Events(ViewSet):
         Returns:
             Response -- JSON serialized list of events
         """
+        # Get the current authenticated user
+        gamer = Gamer.objects.get(user=request.auth.user)
         events = Event.objects.all()
+
+        # Set the `joined` property on every event
+        for event in events:
+            event.joined = None
+
+            try:
+                EventGamer.objects.get(event=event, gamer=gamer)
+                event.joined = True
+            except EventGamer.DoesNotExist:
+                event.joined = False
 
         # Support filtering events by game
         game = self.request.query_params.get('gameId', None)
         if game is not None:
-            events = events.filter(game__id=game)
+            events = events.filter(game__id=type)
 
         serializer = EventSerializer(
             events, many=True, context={'request': request})
@@ -202,6 +214,6 @@ class EventSerializer(serializers.HyperlinkedModelSerializer):
             lookup_field='id'
         )
         fields = ('id', 'url', 'game', 'gamer',
-                  'description', 'day', 'time')
+                  'description', 'day', 'time', 'joined')
 
                   


### PR DESCRIPTION
# Description
The client wants to be able to sign gamers up for events using a custom signup action. This change allows the user to make POST or DELETE requests to /events/eventId/signup, which will create or delete an entry in the gamerEvents table.
## Type of change
- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Send a POST to `http://localhost:8000/events/1/signup` and verify that the resource is created in the database
- [x] Send a second POST to `http://localhost:8000/events/1/signup` and verify that the api responds that the resource has already been created
- [x] Send a DELETE to `http://localhost:8000/events/1/signup` and verify that the resource is deleted in the database
# Checklist:
- [x] Send a second DELETE to `http://localhost:8000/events/1/signup` and verify that the response is 404 NOT FOUND
